### PR TITLE
Use "occurred" instead of "occured"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ gh workflow run rubocop-todo-corrector
 - Choose from the following options:
   - `"first"`
   - `"last"`
-  - `"least_occured"`
-  - `"most_occured"`
+  - `"least_occurred"`
+  - `"most_occurred"`
   - `"random"`


### PR DESCRIPTION
The same spelling correction was made here accordingly: https://github.com/r7kamura/rubocop_todo_corrector/pull/3

Use "occurred" instead of "occured"