### PR TITLE
Fix only_safe argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+- Fix bug about `only_safe` argument.
+
 ## 0.8.2 - 2022-05-30
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   only_safe:
     description: Exclude unsafe cops.
     required: false
-    default: true
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -32,14 +32,14 @@ runs:
     - name: rubocop_todo_corrector pick
       id: pick
       run: |
-        cop_name=$(rubocop_todo_corrector pick --mode="${{ inputs.mode }}" ${{ inputs.only_safe == 'true' && '--only-safe' || '' }})
+        cop_name=$(rubocop_todo_corrector pick --mode="${{ inputs.mode }}" ${{ inputs.only_safe != 'true' && '--no-only-safe' || '' }})
         echo "::set-output name=cop_name::${cop_name}"
       shell: bash
     - name: rubocop_todo_corrector remove
       run: rubocop_todo_corrector remove --cop-name="${{ steps.pick.outputs.cop_name }}"
       shell: bash
     - name: rubocop_todo_corrector correct
-      run: rubocop_todo_corrector correct ${{ inputs.only_safe == 'true' && '--only-safe' || '' }}
+      run: rubocop_todo_corrector correct ${{ inputs.only_safe != 'true' && '--no-only-safe' || '' }}
       shell: bash
     - name: rubocop_todo_corrector generate
       run: rubocop_todo_corrector generate


### PR DESCRIPTION
引数なしで`pick`と`correct`を行なうと`rubocop -A`になっていなかったので修正しました