### PR TITLE
Add new input: `working_directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you use GitHub App to generate access tokens, the permission would look like 
 - Pass `"false"` if you want it to include unsafe autocorrection.
 - optional
 
-### `working-directory`
+### `working_directory`
 
 - Specify working directory.
 - optional

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ If you use GitHub App to generate access tokens, the permission would look like 
 - Pass `"false"` if you want it to include unsafe autocorrection.
 - optional
 
+### `working-directory`
+
+- Specify working directory.
+- optional
+- default: `"."`
+
 ## Example
 
 The below example is how we use this in our company:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: Exclude unsafe cops.
     required: false
     default: "true"
-  working-directory:
+  working_directory:
     description: Working directory.
     required: false
     default: "."
@@ -111,7 +111,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.working_directory }}
 branding:
   color: red
   icon: git-pull-request

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Exclude unsafe cops.
     required: false
     default: "true"
+  working-directory:
+    description: Working directory.
+    required: false
+    default: "."
 runs:
   using: composite
   steps:
@@ -107,6 +111,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 branding:
   color: red
   icon: git-pull-request


### PR DESCRIPTION
## Background
Some projects have ruby ​​applications in locations other than the root directory. In this case, I thought that I would like to run this workflow in an arbitrary directory, so I would like to add the designation of `working-directory`

## Changes
* Add `working-directory` to input.
  * This parameter follows the GitHub Actions specification and is passed as-is to the workflow's `working-directory` keyword. 
  * Default value is the current directory.
* Edit README.

## Operation check
~We have not been able to confirm the operation of this change, so please guide us on the next process.~

https://github.com/r7kamura/rubocop-todo-corrector/pull/27#issuecomment-1438141855
I confirmed the operation according to the reference above.