### PR TITLE
Change actions/checkout version from v3 to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       with:
         bundler-cache: true
         ruby-version: 3.1
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # We want to always get the default branch ref.
         ref: "${{ github.event.pull_request.base.ref }}"


### PR DESCRIPTION
This warning will appear when run the rubocop-todo-corrector.

<img width="1041" alt="スクリーンショット 2024-03-01 15 34 54" src="https://github.com/r7kamura/rubocop-todo-corrector/assets/425216/03374101-f37b-4838-a77d-fd0407f79527">
